### PR TITLE
pyproject.toml -> drop py38,py39 limit to py313. other tweaks to follow python best practices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A Python library for Gordon Surface interpolation using B-splines."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">= 3.10, < 3.14"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "cadquery-ocp >= 7.8, < 7.9",
-    "numpy  >= 2, < 3",
+    "numpy >= 2, < 3",
     "scipy",
 ]
 keywords = [
@@ -30,14 +30,14 @@ keywords = [
     "cad",
     "cadquery",
     "build123d",
-    "opencscade",
+    "opencascade",
     "python",
 ]
 license = "Apache-2.0"
 
 [project.urls]
-"Homepage" = "https://github.com/gongfan99/ocp_gordon"
-"Bug Tracker" = "https://github.com/gongfan99/ocp_gordon/issues"
+homepage = "https://github.com/gongfan99/ocp_gordon"
+issues = "https://github.com/gongfan99/ocp_gordon/issues"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
I noticed that this repo has a wider python version compatibility than `cadquery-ocp >= 7.8, < 7.9` provides packages for (py310 through py313). Also python 3.8 is already EOL, and python 3.9 will be EOL at the end of this month.

I made a few other tweaks to follow URL naming https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels and some typo fixes.