### PR TITLE
Add a setup action and a test workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,18 @@
+name: 'Setup'
+inputs:
+  python-version:
+    description: 'Python version'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: false
+        python-version: ${{ inputs.python-version }}
+    - name: Install Requirements
+      shell: bash
+      run: |
+        uv pip install .[test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: test
+
+on: [push, pull_request, workflow_dispatch]
+jobs:
+
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+        os: [macos-13, macos-14, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup/
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: test
+        run: |
+          python -m pytest -n auto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: test
         run: |
-          python -m pytest -n auto
+          python -m pytest


### PR DESCRIPTION
Added:
1. a setup action to setup python and required dependencies (currently just `.[test]`)
2. a testing workflow for cross platform testing (mac x86_64, mac arm64, linux x86_64, windows x86_64) on python 3.10. This is currently setup to run on push/pull and workflow dispatches. I also chose to use `uv` as it makes these workflows run very quickly.

I did NOT make any changes to release.yml.