### PR TITLE
run pyupgrade --py310plus on `ocp_gordon` package and tests

### DIFF
--- a/src_py/ocp_gordon/internal/approx_result.py
+++ b/src_py/ocp_gordon/internal/approx_result.py
@@ -12,6 +12,6 @@ class ApproxResult:
     """
     Structure to hold the result of a B-spline approximation/interpolation.
     """
-    def __init__(self, curve: Optional[Geom_BSplineCurve] = None, error: float = 0.0):
+    def __init__(self, curve: Geom_BSplineCurve | None = None, error: float = 0.0):
         self.curve = curve
         self.error = error

--- a/src_py/ocp_gordon/internal/bspline_algorithms.py
+++ b/src_py/ocp_gordon/internal/bspline_algorithms.py
@@ -47,7 +47,7 @@ class BSplineAlgorithms:
         return abs(value - target) < tolerance
 
     @staticmethod
-    def linspace_with_breaks(umin: float, umax: float, n_values: int, breaks: List[float]) -> List[float]:
+    def linspace_with_breaks(umin: float, umax: float, n_values: int, breaks: list[float]) -> list[float]:
         """
         Generates a sequence of evenly spaced values over a specified interval,
         including specified break points. This is a Python port of the C++
@@ -139,7 +139,7 @@ class BSplineAlgorithms:
         return v_dir_closed
 
     @staticmethod
-    def get_kink_parameters(curve: Geom_BSplineCurve) -> List[float]:
+    def get_kink_parameters(curve: Geom_BSplineCurve) -> list[float]:
         if curve is None:
             raise error("Null Pointer curve", ErrorCode.NULL_POINTER) # Use ErrorCode
 
@@ -167,8 +167,8 @@ class BSplineAlgorithms:
 
     class SurfaceKinks: # Define SurfaceKinks as a nested class
         def __init__(self):
-            self.u: List[float] = []
-            self.v: List[float] = []
+            self.u: list[float] = []
+            self.v: list[float] = []
 
     @staticmethod
     def get_kink_parameters_surface(surface: Geom_BSplineSurface) -> 'BSplineAlgorithms.SurfaceKinks':
@@ -196,7 +196,7 @@ class BSplineAlgorithms:
     
     @staticmethod
     def compute_params_bspline_curve(points: TColgp_HArray1OfPnt, 
-                                   alpha: float = 0.5) -> List[float]:
+                                   alpha: float = 0.5) -> list[float]:
         """
         Computes parameters of a B-spline curve at given points.
         
@@ -238,7 +238,7 @@ class BSplineAlgorithms:
         return params
     
     @staticmethod
-    def match_parameter_range(bsplines: List[Geom_BSplineCurve], 
+    def match_parameter_range(bsplines: list[Geom_BSplineCurve], 
                             tolerance: float = 1e-15) -> None:
         """
         Matches parameter range of all B-splines to the first B-spline.
@@ -262,7 +262,7 @@ class BSplineAlgorithms:
                 BSplineAlgorithms.reparametrize_bspline(spline, umin_ref, umax_ref, tolerance)
     
     @staticmethod
-    def match_degree(bsplines: List[Geom_BSplineCurve]) -> None:
+    def match_degree(bsplines: list[Geom_BSplineCurve]) -> None:
         """
         Matches degree of all B-splines by raising to maximum degree.
         
@@ -282,8 +282,8 @@ class BSplineAlgorithms:
                 spline.IncreaseDegree(max_degree)
     
     @staticmethod
-    def create_common_knots_vector_curve(splines_vector: List[Geom_BSplineCurve],
-                                       tol: float) -> List[Geom_BSplineCurve]:
+    def create_common_knots_vector_curve(splines_vector: list[Geom_BSplineCurve],
+                                       tol: float) -> list[Geom_BSplineCurve]:
         """
         Creates common knots vector for given B-splines.
         
@@ -365,7 +365,7 @@ class BSplineAlgorithms:
         spline.SetKnots(knots_array)
     
     @staticmethod
-    def to_bsplines(curves: List[Geom_Curve]) -> List[Geom_BSplineCurve]:
+    def to_bsplines(curves: list[Geom_Curve]) -> list[Geom_BSplineCurve]:
         """
         Converts a curve array into a B-spline array.
         
@@ -389,7 +389,7 @@ class BSplineAlgorithms:
     @staticmethod
     def intersections(spline1: Geom_BSplineCurve, 
                      spline2: Geom_BSplineCurve, 
-                     tolerance: float = 3e-4) -> List[Tuple[float, float]]:
+                     tolerance: float = 3e-4) -> list[tuple[float, float]]:
         """
         Returns all intersections of two B-splines.
         
@@ -429,7 +429,7 @@ class BSplineAlgorithms:
         return scale_val if scale_val > 0 else 1.0
 
     @staticmethod
-    def _scale_curve_list(splines_vector: List[Geom_BSplineCurve]) -> float:
+    def _scale_curve_list(splines_vector: list[Geom_BSplineCurve]) -> float:
         """
         Returns the approximate scale of the biggest B-spline curve in a list.
         Matches the C++ scale(const std::vector<Handle(Geom_BSplineCurve)>& splines_vector) function.
@@ -467,7 +467,7 @@ class BSplineAlgorithms:
         return the_scale if the_scale > 0 else 1.0 # Ensure non-zero scale
 
     @staticmethod
-    def scale(obj: Union[Geom_BSplineCurve, List[Geom_BSplineCurve], TColgp_Array2OfPnt, TColgp_Array1OfPnt]) -> float:
+    def scale(obj: Geom_BSplineCurve | list[Geom_BSplineCurve] | TColgp_Array2OfPnt | TColgp_Array1OfPnt) -> float:
         """
         Returns the approximate scale of the given B-spline curve(s) or point array(s).
         This is a unified method to match the overloaded C++ scale functions.
@@ -485,7 +485,7 @@ class BSplineAlgorithms:
 
     # Helper methods
     @staticmethod
-    def _get_knots(spline: Geom_BSplineCurve) -> List[float]:
+    def _get_knots(spline: Geom_BSplineCurve) -> list[float]:
         """Get all knots from a B-spline curve."""
         knots = []
         n_knots = spline.NbKnots()
@@ -503,7 +503,7 @@ class BSplineAlgorithms:
         return 0
     
     @staticmethod
-    def _get_poles(spline: Geom_BSplineCurve) -> List[gp_Pnt]:
+    def _get_poles(spline: Geom_BSplineCurve) -> list[gp_Pnt]:
         """Get all poles from a B-spline curve."""
         poles = []
         n_poles = spline.NbPoles()
@@ -512,7 +512,7 @@ class BSplineAlgorithms:
         return poles
     
     @staticmethod
-    def _get_weights(spline: Geom_BSplineCurve) -> List[float]:
+    def _get_weights(spline: Geom_BSplineCurve) -> list[float]:
         """Get all weights from a rational B-spline curve."""
         if not spline.IsRational():
             return [1.0] * spline.NbPoles()
@@ -524,8 +524,8 @@ class BSplineAlgorithms:
         return weights
     
     @staticmethod
-    def _insert_knots(spline: Geom_BSplineCurve, knots: List[float], 
-                     multiplicities: List[int], tol: float) -> Geom_BSplineCurve:
+    def _insert_knots(spline: Geom_BSplineCurve, knots: list[float], 
+                     multiplicities: list[int], tol: float) -> Geom_BSplineCurve:
         """
         Insert knots into a B-spline curve.
         
@@ -563,8 +563,8 @@ class BSplineAlgorithms:
     
     @staticmethod
     def reparametrize_bspline_continuously_approx(spline: Geom_BSplineCurve,
-                                                  old_parameters: List[float],
-                                                  new_parameters: List[float],
+                                                  old_parameters: list[float],
+                                                  new_parameters: list[float],
                                                   n_control_pnts: int) -> ApproxResult: # Note: C++ returns ApproxResult
         """
         Reparametrize B-spline curve using approximation, matching C++ line by line.
@@ -734,7 +734,7 @@ class BSplineAlgorithms:
         return GeomConvert.CurveToBSplineCurve_s(curve)
 
     @staticmethod
-    def knots_from_curve_parameters(params: List[float], degree: int, closed_curve: bool = False) -> List[float]:
+    def knots_from_curve_parameters(params: list[float], degree: int, closed_curve: bool = False) -> list[float]:
         """
         Create knot vector from curve parameters following Park (2000) algorithm.
         
@@ -883,7 +883,7 @@ class BSplineAlgorithms:
         return low
 
     @staticmethod
-    def _basis_functions(knots: TColStd_Array1OfReal, span_idx: int, param: float, degree: int) -> List[float]:
+    def _basis_functions(knots: TColStd_Array1OfReal, span_idx: int, param: float, degree: int) -> list[float]:
         """Compute B-spline basis functions for a given span."""
         left = [0.0] * (degree + 1)
         right = [0.0] * (degree + 1)
@@ -941,7 +941,7 @@ class BSplineAlgorithms:
                 and c2_continuous)
 
     @staticmethod
-    def to_array(vector: List[float]) -> TColStd_HArray1OfReal:
+    def to_array(vector: list[float]) -> TColStd_HArray1OfReal:
         """
         Convert Python list to TColStd_HArray1OfReal.
         
@@ -957,7 +957,7 @@ class BSplineAlgorithms:
         return array
 
     @staticmethod
-    def to_array_int(vector: List[int]) -> TColStd_HArray1OfInteger:
+    def to_array_int(vector: list[int]) -> TColStd_HArray1OfInteger:
         """
         Convert Python list to TColStd_HArray1OfInteger.
         
@@ -1001,7 +1001,7 @@ class BSplineAlgorithms:
         return row_vector
 
     @staticmethod
-    def compute_params_bspline_surf(points: TColgp_Array2OfPnt, alpha: float = 0.5) -> Tuple[List[float], List[float]]:
+    def compute_params_bspline_surf(points: TColgp_Array2OfPnt, alpha: float = 0.5) -> tuple[list[float], list[float]]:
         """
         Computes parameters for a B-spline surface in both u and v directions.
         Matches the C++ computeParamsBSplineSurf function line by line.
@@ -1066,7 +1066,7 @@ class BSplineAlgorithms:
         return result
 
     @staticmethod
-    def _insert_knot_with_multiplicity(knot: float, count: int, degree: int, knots: List[float], mults: List[int], tol: float = 1e-5):
+    def _insert_knot_with_multiplicity(knot: float, count: int, degree: int, knots: list[float], mults: list[int], tol: float = 1e-5):
         """
         Inserts a knot into the knot vector with a specified multiplicity,
         similar to the C++ insertKnot helper function.
@@ -1173,7 +1173,7 @@ class BSplineAlgorithms:
 
 
     @staticmethod
-    def have_same_range(splines_vector: List[Union['BSplineAlgorithms.SurfAdapterView', 'BSplineAlgorithms.CurveAdapterView']], par_tolerance: float) -> bool:
+    def have_same_range(splines_vector: list[Union['BSplineAlgorithms.SurfAdapterView', 'BSplineAlgorithms.CurveAdapterView']], par_tolerance: float) -> bool:
         """
         Checks if all splines in the vector have the same parameter range.
         This is a generic helper for both curves and surfaces (via adapters).

--- a/src_py/ocp_gordon/internal/bspline_approx_interp.py
+++ b/src_py/ocp_gordon/internal/bspline_approx_interp.py
@@ -37,9 +37,9 @@ class BSplineApproxInterp:
         for i in range(points.Lower(), points.Upper() + 1):
             self.m_pnts.SetValue(i, points(i))
 
-        self.m_index_of_approximated: List[int] = list(range(points.Length()))
-        self.m_index_of_interpolated: List[int] = []
-        self.m_index_of_kinks: List[int] = []
+        self.m_index_of_approximated: list[int] = list(range(points.Length()))
+        self.m_index_of_interpolated: list[int] = []
+        self.m_index_of_kinks: list[int] = []
 
         self.m_degree = degree
         self.m_ncp = n_control_points
@@ -85,7 +85,7 @@ class BSplineApproxInterp:
         last = (self.m_pnts.Length() - 1) in self.m_index_of_interpolated
         return first and last
 
-    def _compute_parameters(self, alpha: float) -> List[float]:
+    def _compute_parameters(self, alpha: float) -> list[float]:
         sum_len = 0.0
         n_points = self.m_pnts.Length()
         params = [0.0] * n_points
@@ -112,7 +112,7 @@ class BSplineApproxInterp:
             params[n_points - 1] = 1.0
         return params
 
-    def _compute_knots(self, ncp: int, params: List[float]) -> Tuple[List[float], List[int]]:
+    def _compute_knots(self, ncp: int, params: list[float]) -> tuple[list[float], list[int]]:
         order = self.m_degree + 1
         if ncp < order:
             raise error("Number of control points too small!", ErrorCode.MATH_ERROR)
@@ -120,8 +120,8 @@ class BSplineApproxInterp:
         umin = min(params)
         umax = max(params)
 
-        knots: List[float] = [0.0] * (ncp - self.m_degree + 1)
-        mults: List[int] = [0] * (ncp - self.m_degree + 1)
+        knots: list[float] = [0.0] * (ncp - self.m_degree + 1)
+        mults: list[int] = [0] * (ncp - self.m_degree + 1)
 
         # fill multiplicity at start
         knots[0] = umin
@@ -144,7 +144,7 @@ class BSplineApproxInterp:
 
         return knots, mults
 
-    def fit_curve(self, initial_params: Optional[List[float]] = None) -> ApproxResult:
+    def fit_curve(self, initial_params: list[float] | None = None) -> ApproxResult:
         params = initial_params if initial_params is not None and initial_params else self._compute_parameters(0.5)
 
         if len(params) != self.m_pnts.Length():
@@ -163,7 +163,7 @@ class BSplineApproxInterp:
 
         return self._solve(params, knots_array, mults_array)
 
-    def fit_curve_optimal(self, initial_params: Optional[List[float]] = None, max_iter: int = 10) -> ApproxResult:
+    def fit_curve_optimal(self, initial_params: list[float] | None = None, max_iter: int = 10) -> ApproxResult:
         params = initial_params if initial_params is not None and initial_params else self._compute_parameters(0.5)
 
         if len(params) != self.m_pnts.Length():
@@ -211,7 +211,7 @@ class BSplineApproxInterp:
             # Fallback if projection fails, return initial parameter with large error
             return ProjectResult(initial_param, float('inf'))
 
-    def _get_continuity_matrix(self, n_ctr_pnts: int, contin_cons: int, params: List[float], flat_knots: TColStd_Array1OfReal) -> np.ndarray:
+    def _get_continuity_matrix(self, n_ctr_pnts: int, contin_cons: int, params: list[float], flat_knots: TColStd_Array1OfReal) -> np.ndarray:
         continuity_entries = np.zeros((contin_cons, n_ctr_pnts))
 
         # Need to convert single float to TColStd_Array1OfReal for bspline_basis_mat
@@ -240,7 +240,7 @@ class BSplineApproxInterp:
         
         return continuity_entries
 
-    def _solve(self, params: List[float], knots: TColStd_Array1OfReal, mults: TColStd_Array1OfInteger) -> ApproxResult:
+    def _solve(self, params: list[float], knots: TColStd_Array1OfReal, mults: TColStd_Array1OfInteger) -> ApproxResult:
         # compute flat knots
         n_flat_knots = BSplCLib.KnotSequenceLength_s(mults, self.m_degree, False)
         flat_knots_array = TColStd_Array1OfReal(1, n_flat_knots)
@@ -383,7 +383,7 @@ class BSplineApproxInterp:
         
         return ApproxResult(curve=result_curve, error=max_error)
 
-    def _optimize_parameters(self, curve: Geom_Curve, params: List[float]):
+    def _optimize_parameters(self, curve: Geom_Curve, params: list[float]):
         # optimize each parameter by finding it's position on the curve
         for idx in self.m_index_of_approximated:
             pnt_idx = self.m_pnts.Lower() + idx

--- a/src_py/ocp_gordon/internal/curve_network_sorter.py
+++ b/src_py/ocp_gordon/internal/curve_network_sorter.py
@@ -69,8 +69,8 @@ class CurveNetworkSorter:
     """
     
     def __init__(self,
-                 profiles: List[Geom_Curve],
-                 guides: List[Geom_Curve],
+                 profiles: list[Geom_Curve],
+                 guides: list[Geom_Curve],
                  parms_inters_profiles: np.ndarray,
                  parms_inters_guides: np.ndarray):
         
@@ -168,7 +168,7 @@ class CurveNetworkSorter:
         self._parms_inters_guides[:, [idx1, idx2]] = self._parms_inters_guides[:, [idx2, idx1]]
         self._parms_inters_profiles[:, [idx1, idx2]] = self._parms_inters_profiles[:, [idx2, idx1]]
 
-    def get_start_curve_indices(self) -> Tuple[int, int, bool]:
+    def get_start_curve_indices(self) -> tuple[int, int, bool]:
         # find curves, that begin at the same point (have the smallest parameter at their intersection)
         for irow in range(self.NProfiles()):
             jmin = min_row_index(self._parms_inters_profiles, irow)
@@ -198,10 +198,10 @@ class CurveNetworkSorter:
     def NGuides(self) -> int:
         return len(self._guides)
 
-    def ProfileIndices(self) -> List[str]:
+    def ProfileIndices(self) -> list[str]:
         return self._prof_idx
 
-    def GuideIndices(self) -> List[str]:
+    def GuideIndices(self) -> list[str]:
         return self._guid_idx
 
     def reverse_profile(self, profile_idx: int):

--- a/src_py/ocp_gordon/internal/curves_to_surface.py
+++ b/src_py/ocp_gordon/internal/curves_to_surface.py
@@ -64,7 +64,7 @@ class CurvesToSurface:
     mirror the C++ version's functionality.
     """
     
-    def __init__(self, curves: List[Geom_Curve], parameters: Optional[List[float]] = None, continuous_if_closed: bool = False, tolerance: float = 1e-14):
+    def __init__(self, curves: list[Geom_Curve], parameters: list[float] | None = None, continuous_if_closed: bool = False, tolerance: float = 1e-14):
         """
         Initialize the surface skinner.
         
@@ -84,8 +84,8 @@ class CurvesToSurface:
         self._has_performed = False
         self._skinned_surface = None
         
-        self._input_curves: List[Geom_BSplineCurve] = []
-        self._compatible_splines: List[Geom_BSplineCurve] = [] # Initialize _compatible_splines here
+        self._input_curves: list[Geom_BSplineCurve] = []
+        self._compatible_splines: list[Geom_BSplineCurve] = [] # Initialize _compatible_splines here
         
         # Convert all curves to bspline curves and store them
         for curve in self._input_curves_raw:
@@ -113,7 +113,7 @@ class CurvesToSurface:
         self._max_degree = degree
         self.invalidate() # Invalidate cached surface
 
-    def get_parameters(self) -> List[float]:
+    def get_parameters(self) -> list[float]:
         """Returns the parameters at the profile curves (v-direction)."""
         return self._parameters
 

--- a/src_py/ocp_gordon/internal/gordon_surface_builder.py
+++ b/src_py/ocp_gordon/internal/gordon_surface_builder.py
@@ -29,10 +29,10 @@ class GordonSurfaceBuilder:
     """
     
     def __init__(self,
-                 profiles: List[Geom_BSplineCurve],
-                 guides: List[Geom_BSplineCurve],
-                 intersection_params_spline_u: List[float],
-                 intersection_params_spline_v: List[float],
+                 profiles: list[Geom_BSplineCurve],
+                 guides: list[Geom_BSplineCurve],
+                 intersection_params_spline_u: list[float],
+                 intersection_params_spline_v: list[float],
                  tolerance: float):
         """
         Initialize the Gordon surface builder.
@@ -98,8 +98,8 @@ class GordonSurfaceBuilder:
     # Due to circular import issues, these two functions are implemented directly in this file instead of being imported from bspline_algorithms.py    
     @staticmethod
     def _points_to_surface_internal(points: TColgp_Array2OfPnt,
-                                    u_params: List[float],
-                                    v_params: List[float],
+                                    u_params: list[float],
+                                    v_params: list[float],
                                     make_u_closed: bool,
                                     make_v_closed: bool) -> Geom_BSplineSurface:
         """
@@ -107,7 +107,7 @@ class GordonSurfaceBuilder:
         Matches the C++ BSplineAlgorithms::pointsToSurface function.
         """
         # 1. Interpolate curves in U-direction (along rows)
-        u_direction_curves: List[Geom_BSplineCurve] = []
+        u_direction_curves: list[Geom_BSplineCurve] = []
         for col_idx in range(points.LowerCol(), points.UpperCol() + 1):
             # Extract a row of points as a 1D array
             points_u_line = BSplineAlgorithms._pnt_array2_get_column(points, col_idx)
@@ -126,9 +126,9 @@ class GordonSurfaceBuilder:
         return skinner.surface()
 
     @staticmethod
-    def _create_common_knots_vector_surface_internal(surfaces_vector: List[Geom_BSplineSurface],
+    def _create_common_knots_vector_surface_internal(surfaces_vector: list[Geom_BSplineSurface],
                                                      direction: SurfaceDirection,
-                                                     tol: float = 1e-7) -> List[Geom_BSplineSurface]:
+                                                     tol: float = 1e-7) -> list[Geom_BSplineSurface]:
         """
         Creates common knot vectors for a list of B-spline surfaces in the specified direction(s).
         Matches the C++ BSplineAlgorithms::createCommonKnotsVectorSurface function.
@@ -205,7 +205,7 @@ class GordonSurfaceBuilder:
 
         return result_surfaces
 
-    def _create_gordon_surface(self, profiles: List[Geom_BSplineCurve], guides: List[Geom_BSplineCurve], intersection_params_spline_u: List[float], intersection_params_spline_v: List[float]):
+    def _create_gordon_surface(self, profiles: list[Geom_BSplineCurve], guides: list[Geom_BSplineCurve], intersection_params_spline_u: list[float], intersection_params_spline_v: list[float]):
         """
         Create the Gordon surface using the C++ algorithm.
         
@@ -330,7 +330,7 @@ class GordonSurfaceBuilder:
             abs(curve.LastParameter() - umax) > tol):
             raise error(f"Curve not in range [{umin}, {umax}].", ErrorCode.MATH_ERROR)
     
-    def _check_curve_network_compatibility(self, profiles: List[Geom_BSplineCurve], guides: List[Geom_BSplineCurve], intersection_params_spline_u, intersection_params_spline_v, tol):
+    def _check_curve_network_compatibility(self, profiles: list[Geom_BSplineCurve], guides: list[Geom_BSplineCurve], intersection_params_spline_u, intersection_params_spline_v, tol):
         """Check if the curve network is compatible."""
         # Find the 'average' scale of the B-splines
         splines_scale = 0.5 * (BSplineAlgorithms.scale(profiles) + BSplineAlgorithms.scale(guides))

--- a/src_py/ocp_gordon/internal/interpolate_curve_network.py
+++ b/src_py/ocp_gordon/internal/interpolate_curve_network.py
@@ -39,8 +39,8 @@ class SurfaceConstructionError(GordonInterpolationError):
 
 
 def interpolate_curve_network(
-    ucurves: List[Union[Geom_Curve, Geom_BSplineCurve]],
-    vcurves: List[Union[Geom_Curve, Geom_BSplineCurve]],
+    ucurves: list[Geom_Curve | Geom_BSplineCurve],
+    vcurves: list[Geom_Curve | Geom_BSplineCurve],
     tolerance: float = 3e-4
 ) -> Geom_BSplineSurface:
     """
@@ -88,8 +88,8 @@ class InterpolateCurveNetwork:
     
     def __init__(
         self,
-        profiles: List[Geom_BSplineCurve],
-        guides: List[Geom_BSplineCurve],
+        profiles: list[Geom_BSplineCurve],
+        guides: list[Geom_BSplineCurve],
         spatial_tolerance: float
     ):
         """
@@ -107,7 +107,7 @@ class InterpolateCurveNetwork:
             raise InvalidInputError("There must be at least two guides for the curve network interpolation.")
 
         # Remove duplicates from profiles and guides (integrated logic)
-        unique_profiles: List[Geom_BSplineCurve] = []
+        unique_profiles: list[Geom_BSplineCurve] = []
         for profile in profiles:
             is_unique = True
             for unique_profile in unique_profiles:
@@ -117,7 +117,7 @@ class InterpolateCurveNetwork:
             if is_unique:
                 unique_profiles.append(profile)
 
-        unique_guides: List[Geom_BSplineCurve] = []
+        unique_guides: list[Geom_BSplineCurve] = []
         for guide in guides:
             is_unique = True
             for unique_guide in unique_guides:
@@ -139,12 +139,12 @@ class InterpolateCurveNetwork:
         self.has_performed = False
         
         # Results storage
-        self.skinning_surf_profiles: Optional[Geom_BSplineSurface] = None
-        self.skinning_surf_guides: Optional[Geom_BSplineSurface] = None
-        self.tensor_prod_surf: Optional[Geom_BSplineSurface] = None
-        self.gordon_surf: Optional[Geom_BSplineSurface] = None
-        self.intersection_params_u: List[float] = [] # Stores final reparametrized parameters
-        self.intersection_params_v: List[float] = [] # Stores final reparametrized parameters
+        self.skinning_surf_profiles: Geom_BSplineSurface | None = None
+        self.skinning_surf_guides: Geom_BSplineSurface | None = None
+        self.tensor_prod_surf: Geom_BSplineSurface | None = None
+        self.gordon_surf: Geom_BSplineSurface | None = None
+        self.intersection_params_u: list[float] = [] # Stores final reparametrized parameters
+        self.intersection_params_v: list[float] = [] # Stores final reparametrized parameters
 
     def perform(self):
         """Perform the complete Gordon surface interpolation."""
@@ -204,12 +204,12 @@ class InterpolateCurveNetwork:
         assert self.tensor_prod_surf is not None
         return self.tensor_prod_surf
 
-    def parameters_profiles(self) -> List[float]:
+    def parameters_profiles(self) -> list[float]:
         """Returns the parameters at the profile curves (v-direction)."""
         self.perform()
         return self.intersection_params_u # intersection_params_v in C++, likely error
 
-    def parameters_guides(self) -> List[float]:
+    def parameters_guides(self) -> list[float]:
         """Returns the parameters at the guide curves (u-direction)."""
         self.perform()
         return self.intersection_params_v # intersection_params_u in C++, likely error
@@ -508,8 +508,8 @@ class InterpolateCurveNetwork:
 
 
 def interpolate_curve_network_debug(
-    ucurves: List[Union[Geom_Curve, Geom_BSplineCurve]],
-    vcurves: List[Union[Geom_Curve, Geom_BSplineCurve]],
+    ucurves: list[Geom_Curve | Geom_BSplineCurve],
+    vcurves: list[Geom_Curve | Geom_BSplineCurve],
     tolerance: float = 3e-4
 ) -> InterpolateCurveNetwork:
     """

--- a/src_py/ocp_gordon/internal/intersect_bsplines.py
+++ b/src_py/ocp_gordon/internal/intersect_bsplines.py
@@ -206,7 +206,7 @@ class CurveCurveDistanceObjective(math_MultipleVarFunctionWithGradient):
 
         return True
 
-def getRangesOfIntersection(curve1: Geom_BSplineCurve, curve2: Geom_BSplineCurve, tolerance: float) -> List[BoundingBoxPair]:
+def getRangesOfIntersection(curve1: Geom_BSplineCurve, curve2: Geom_BSplineCurve, tolerance: float) -> list[BoundingBoxPair]:
     h1 = BoundingBox(curve1)
     h2 = BoundingBox(curve2)
     
@@ -278,11 +278,11 @@ class IntersectType(TypedDict):
     parmOnCurve2: float
     point: gp_Pnt
 
-def IntersectBSplines(curve1: Geom_BSplineCurve, curve2: Geom_BSplineCurve, tolerance: float = 1e-5) -> List[IntersectType]:
+def IntersectBSplines(curve1: Geom_BSplineCurve, curve2: Geom_BSplineCurve, tolerance: float = 1e-5) -> list[IntersectType]:
     hulls = getRangesOfIntersection(curve1, curve2, tolerance)
     
-    curve1_ints: List[BoundingBox] = []
-    curve2_ints: List[BoundingBox] = []
+    curve1_ints: list[BoundingBox] = []
+    curve2_ints: list[BoundingBox] = []
     for hull in hulls:
         curve1_ints.append(hull.b1)
         curve2_ints.append(hull.b2)
@@ -290,7 +290,7 @@ def IntersectBSplines(curve1: Geom_BSplineCurve, curve2: Geom_BSplineCurve, tole
     curve1_ints.sort(key=lambda b: b.range.min)
     curve2_ints.sort(key=lambda b: b.range.min)
 
-    unique_curve1_ints: List[BoundingBox] = []
+    unique_curve1_ints: list[BoundingBox] = []
     if curve1_ints:
         unique_curve1_ints.append(curve1_ints[0])
         for i in range(1, len(curve1_ints)):
@@ -298,7 +298,7 @@ def IntersectBSplines(curve1: Geom_BSplineCurve, curve2: Geom_BSplineCurve, tole
                 unique_curve1_ints.append(curve1_ints[i])
     curve1_ints = unique_curve1_ints
 
-    unique_curve2_ints: List[BoundingBox] = []
+    unique_curve2_ints: list[BoundingBox] = []
     if curve2_ints:
         unique_curve2_ints.append(curve2_ints[0])
         for i in range(1, len(curve2_ints)):
@@ -313,13 +313,13 @@ def IntersectBSplines(curve1: Geom_BSplineCurve, curve2: Geom_BSplineCurve, tole
     replace_adjacent_in_list(curve1_ints, is_adjacent, merge_boxes)
     replace_adjacent_in_list(curve2_ints, is_adjacent, merge_boxes)
     
-    intersectionCandidates: List[BoundingBoxPair] = []
+    intersectionCandidates: list[BoundingBoxPair] = []
     for b1 in curve1_ints:
         for b2 in curve2_ints:
             if b1.Intersects(b2, tolerance):
                 intersectionCandidates.append(BoundingBoxPair(b1, b2))
 
-    results: List[IntersectType] = []
+    results: list[IntersectType] = []
 
     for boxes in intersectionCandidates:
         c1 = BSplineAlgorithms.trimCurve(curve1, boxes.b1.range.min, boxes.b1.range.max)

--- a/src_py/ocp_gordon/internal/misc.py
+++ b/src_py/ocp_gordon/internal/misc.py
@@ -232,7 +232,7 @@ def math_BFGS(
 ) -> bool:
     nb_variables = aFunc.NbVariables()
 
-    def f(args: List[float]):
+    def f(args: list[float]):
         ocp_args = math_Vector(1, nb_variables)
         for i in range(nb_variables):
             ocp_args.SetValue(ocp_args.Lower() + i, args[i])
@@ -243,7 +243,7 @@ def math_BFGS(
             raise RuntimeError(f"function cannot evaluate at {args}")
         return F_k.value
     
-    def g(args: List[float]):
+    def g(args: list[float]):
         ocp_args = math_Vector(1, nb_variables)
         for i in range(nb_variables):
             ocp_args.SetValue(ocp_args.Lower() + i, args[i])

--- a/src_py/ocp_gordon/internal/points_to_bspline_interpolation.py
+++ b/src_py/ocp_gordon/internal/points_to_bspline_interpolation.py
@@ -28,7 +28,7 @@ class PointsToBSplineInterpolation:
     
     def __init__(self,
                  points: TColgp_HArray1OfPnt,
-                 parameters: Optional[List[float]] = None,
+                 parameters: list[float] | None = None,
                  max_degree: int = 3,
                  continuous_if_closed: bool = False):
         """

--- a/tests/test_curve_network_sorter.py
+++ b/tests/test_curve_network_sorter.py
@@ -52,8 +52,8 @@ def create_linear_bspline_curve(
 
 
 @pytest.fixture
-def setup_sorter_data() -> Tuple[
-    List[Geom_BSplineCurve], List[Geom_BSplineCurve], np.ndarray, np.ndarray
+def setup_sorter_data() -> tuple[
+    list[Geom_BSplineCurve], list[Geom_BSplineCurve], np.ndarray, np.ndarray
 ]:
     # Create actual Geom_BSplineCurve instances
     profiles = [

--- a/tests/test_gordon_surface_builder.py
+++ b/tests/test_gordon_surface_builder.py
@@ -17,7 +17,7 @@ from src_py.ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms, Sur
 from src_py.ocp_gordon.internal.error import error, ErrorCode
 
 # Helper function to create a simple B-spline curve
-def create_simple_bspline_curve(points: List[gp_Pnt], degree: int = 3) -> Geom_BSplineCurve:
+def create_simple_bspline_curve(points: list[gp_Pnt], degree: int = 3) -> Geom_BSplineCurve:
     num_poles = len(points)
     
     # Control points

--- a/tests/test_interpolate_curve_network.py
+++ b/tests/test_interpolate_curve_network.py
@@ -55,7 +55,7 @@ def create_bspline_curve(points: list[gp_Pnt]):
     return approximator.Curve()
 
 # Helper function to create a simple B-spline curve
-def create_bspline_curve_from_poles(points: List[gp_Pnt], degree: int = 3) -> Geom_BSplineCurve:
+def create_bspline_curve_from_poles(points: list[gp_Pnt], degree: int = 3) -> Geom_BSplineCurve:
     num_poles = len(points)
     
     # Control points


### PR DESCRIPTION
Per https://github.com/gongfan99/ocp_gordon/pull/1 I noticed some older syntax, and took the opportunity to run `pyupgrade --py310plus` against the codebase (ocp_gordon in src_py and tests).

This PR has a number of changes across most of the python files in this repo. Most common changes are things like `List` -> `list` and `Union[a,b]` -> `a | b`. All changes were generated by `pyupgrade`.

Sorry for the deluge of separate PRs, but I thought these were separate enough changes that you might choose to keep only some of these changes.