### PR TITLE
test.yml -> switch from unavailable macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        os: [macos-13, macos-14, ubuntu-latest, windows-latest]
+        os: [macos-15-intel, macos-14, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The `macos-13` runner is no longer available on free github actions. This PR switches from `macos-13` to `macos-15-intel` (both are x86_64).