### PR TITLE
Change dep to cadquery-ocp-proxy 7.9, add cadquery-ocp-novtk 7.9 to testing workflow, workflow updates

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
       with:
         enable-cache: false
         python-version: ${{ inputs.python-version }}
-        activate-environment: "true"
+        activate-environment: true
     - name: Install Requirements
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,10 +8,11 @@ runs:
   using: "composite"
   steps:
     - name: Setup Python
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: false
         python-version: ${{ inputs.python-version }}
+        activate-environment: "true"
     - name: Install Requirements
       shell: bash
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup/
         with:
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A Python library for Gordon Surface interpolation using B-splines."
 readme = "README.md"
-requires-python = ">= 3.10, < 3.14"
+requires-python = ">= 3.10, < 3.15"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
@@ -18,7 +18,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "cadquery-ocp >= 7.8, < 7.9",
+    "cadquery_ocp_proxy >= 7.9, < 8.0",
     "numpy >= 2, < 3",
     "scipy",
 ]
@@ -42,11 +42,12 @@ issues = "https://github.com/gongfan99/ocp_gordon/issues"
 [project.optional-dependencies]
 test = [
     "pytest",
+    "cadquery_ocp_novtk >=7.9, < 8.0",
 ]
 
 # typing stubs for the OCP CAD kernel
 stubs = [
-    "cadquery-ocp-stubs >= 7.8, < 7.9"
+    "cadquery-ocp-stubs >= 7.9, < 8.0"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Notable changes:

- Changed dependency to cadquery-ocp-proxy 7.9.x
- Added cadquery-ocp-novtk 7.9.x to [test] optional dep category for using during CI testing workflow
- Some updates to workflow actions versions

My advice is when you are ready to release this to PyPI to create a tag (v0.2.0). We can then implement a version range on the build123d side once migration to 7.9.x is complete there.