### PR TITLE
update tests to follow python best practice without src_py prefix and sys.path.insert

### DIFF
--- a/tests/test_bspline_algorithms.py
+++ b/tests/test_bspline_algorithms.py
@@ -1,6 +1,4 @@
 import math
-import os
-import sys
 
 import numpy as np
 import pytest
@@ -18,14 +16,11 @@ from OCP.Precision import Precision
 from OCP.TColgp import TColgp_Array1OfPnt, TColgp_Array2OfPnt, TColgp_HArray1OfPnt
 from OCP.TColStd import TColStd_Array1OfInteger, TColStd_Array1OfReal
 
-# Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
-from src_py.ocp_gordon.internal.bspline_algorithms import (
+from ocp_gordon.internal.bspline_algorithms import (
     BSplineAlgorithms,
     SurfaceDirection,
 )
-from src_py.ocp_gordon.internal.misc import clone_bspline
+from ocp_gordon.internal.misc import clone_bspline
 
 
 # Helper for comparing lists of floats

--- a/tests/test_bspline_approx_interp.py
+++ b/tests/test_bspline_approx_interp.py
@@ -1,24 +1,21 @@
 import pytest
-import sys
-import os
 import numpy as np
 from OCP.Geom import Geom_BSplineCurve, Geom_Curve
 from OCP.TColgp import TColgp_Array1OfPnt
 from OCP.gp import gp_Pnt
 import math
 
-# Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from ocp_gordon.internal.bspline_approx_interp import BSplineApproxInterp, ProjectResult
+from ocp_gordon.internal.error import error, ErrorCode
+from ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms
 
-from src_py.ocp_gordon.internal.bspline_approx_interp import BSplineApproxInterp, ProjectResult
-from src_py.ocp_gordon.internal.error import error, ErrorCode
-from src_py.ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms
 
 # Helper for comparing lists of floats
 def assert_list_almost_equal(list1, list2, places=7):
     assert len(list1) == len(list2)
     for i in range(len(list1)):
-        assert math.isclose(list1[i], list2[i], rel_tol=10**(-places))
+        assert math.isclose(list1[i], list2[i], rel_tol=10 ** (-places))
+
 
 @pytest.fixture
 def simple_points_array():
@@ -29,6 +26,7 @@ def simple_points_array():
     points.SetValue(4, gp_Pnt(3, 0, 0))
     return points
 
+
 @pytest.fixture
 def linear_points_array():
     points = TColgp_Array1OfPnt(1, 3)
@@ -37,6 +35,7 @@ def linear_points_array():
     points.SetValue(3, gp_Pnt(2, 0, 0))
     return points
 
+
 @pytest.fixture
 def closed_points_array():
     points = TColgp_Array1OfPnt(1, 5)
@@ -44,8 +43,9 @@ def closed_points_array():
     points.SetValue(2, gp_Pnt(1, 0, 0))
     points.SetValue(3, gp_Pnt(1, 1, 0))
     points.SetValue(4, gp_Pnt(0, 1, 0))
-    points.SetValue(5, gp_Pnt(0, 0, 0)) # Closed loop
+    points.SetValue(5, gp_Pnt(0, 0, 0))  # Closed loop
     return points
+
 
 class TestBSplineApproxInterp:
 
@@ -71,27 +71,36 @@ class TestBSplineApproxInterp:
         assert 2 in interp.m_index_of_kinks
 
         with pytest.raises(error) as excinfo:
-            interp.interpolate_point(1) # Already interpolated
+            interp.interpolate_point(1)  # Already interpolated
         assert excinfo.value.get_code() == ErrorCode.INDEX_ERROR
 
     def test_max_distance_of_bounding_box(self, simple_points_array):
         interp = BSplineApproxInterp(simple_points_array, n_control_points=5, degree=3)
         dist = interp._max_distance_of_bounding_box(simple_points_array)
         # Bounding box from (0,-1,0) to (3,1,0)
-        expected_dist = gp_Pnt(0,-1,0).Distance(gp_Pnt(3,1,0))
+        expected_dist = gp_Pnt(0, -1, 0).Distance(gp_Pnt(3, 1, 0))
         assert math.isclose(dist, expected_dist, rel_tol=1e-6)
 
     def test_is_closed(self, simple_points_array, closed_points_array):
         # Not C2 continuous, so should return False even if points are closed
-        interp_not_c2 = BSplineApproxInterp(closed_points_array, n_control_points=5, degree=3, continuous_if_closed=False)
+        interp_not_c2 = BSplineApproxInterp(
+            closed_points_array,
+            n_control_points=5,
+            degree=3,
+            continuous_if_closed=False,
+        )
         assert not interp_not_c2.is_closed()
 
         # C2 continuous, and points are closed
-        interp_c2 = BSplineApproxInterp(closed_points_array, n_control_points=5, degree=3, continuous_if_closed=True)
+        interp_c2 = BSplineApproxInterp(
+            closed_points_array, n_control_points=5, degree=3, continuous_if_closed=True
+        )
         assert interp_c2.is_closed()
 
         # Not closed points
-        interp_open = BSplineApproxInterp(simple_points_array, n_control_points=5, degree=3, continuous_if_closed=True)
+        interp_open = BSplineApproxInterp(
+            simple_points_array, n_control_points=5, degree=3, continuous_if_closed=True
+        )
         assert not interp_open.is_closed()
 
     def test_first_and_last_interpolated(self, simple_points_array):
@@ -113,7 +122,9 @@ class TestBSplineApproxInterp:
         # Specific values depend on point distances, check for monotonicity
         assert params[0] <= params[1] <= params[2] <= params[3]
 
-        interp_linear = BSplineApproxInterp(linear_points_array, n_control_points=3, degree=1)
+        interp_linear = BSplineApproxInterp(
+            linear_points_array, n_control_points=3, degree=1
+        )
         params_linear = interp_linear._compute_parameters(0.5)
         assert_list_almost_equal(params_linear, [0.0, 0.5, 1.0])
 
@@ -132,10 +143,12 @@ class TestBSplineApproxInterp:
         assert len(knots) == interp.m_ncp - interp.m_degree + 1
 
         # Test with kinks
-        interp_kink = BSplineApproxInterp(simple_points_array, n_control_points=5, degree=3)
-        interp_kink.interpolate_point(1, with_kink=True) # Add a kink at index 1
+        interp_kink = BSplineApproxInterp(
+            simple_points_array, n_control_points=5, degree=3
+        )
+        interp_kink.interpolate_point(1, with_kink=True)  # Add a kink at index 1
         knots_kink, mults_kink = interp_kink._compute_knots(interp_kink.m_ncp, params)
-        
+
         # The number of knots and mults might increase due to kink insertion
         # The sum of multiplicities should still be ncp + degree + 1, but the structure changes
         # The new _insert_knot_with_multiplicity ensures multiplicity is capped at degree
@@ -147,7 +160,9 @@ class TestBSplineApproxInterp:
         found_kink_knot = False
         for i, k in enumerate(knots_kink):
             if math.isclose(k, kink_param, rel_tol=1e-4):
-                assert mults_kink[i] >= interp_kink.m_degree # Multiplicity should be at least degree
+                assert (
+                    mults_kink[i] >= interp_kink.m_degree
+                )  # Multiplicity should be at least degree
                 found_kink_knot = True
                 break
         assert found_kink_knot
@@ -181,15 +196,15 @@ class TestBSplineApproxInterp:
             p_expected = linear_points_array(i + 1)
             # Optimal parameters might be slightly different, but should still interpolate
             # For linear, they should be the same as computed
-            param = interp._compute_parameters(0.5)[i] # Re-compute for comparison
+            param = interp._compute_parameters(0.5)[i]  # Re-compute for comparison
             p_actual = result.curve.Value(param)
             assert p_expected.IsEqual(p_actual, 1e-6)
 
     def test_fit_curve_with_interpolation(self, simple_points_array):
         interp = BSplineApproxInterp(simple_points_array, n_control_points=4, degree=3)
-        interp.interpolate_point(0) # Interpolate first point
-        interp.interpolate_point(3) # Interpolate last point
-        
+        interp.interpolate_point(0)  # Interpolate first point
+        interp.interpolate_point(3)  # Interpolate last point
+
         result = interp.fit_curve()
         assert result.curve is not None
         assert result.error >= 0.0
@@ -206,8 +221,8 @@ class TestBSplineApproxInterp:
 
     def test_fit_curve_with_kinks(self, simple_points_array):
         interp = BSplineApproxInterp(simple_points_array, n_control_points=5, degree=2)
-        interp.interpolate_point(1, with_kink=True) # Kink at index 1
-        
+        interp.interpolate_point(1, with_kink=True)  # Kink at index 1
+
         result = interp.fit_curve()
         assert result.curve is not None
         assert result.error >= 0.0
@@ -215,7 +230,7 @@ class TestBSplineApproxInterp:
         # Check if the kink parameter has high multiplicity in the resulting curve
         params = interp._compute_parameters(0.5)
         kink_param = params[1]
-        
+
         found_kink_mult = False
         for i in range(1, result.curve.NbKnots() + 1):
             if math.isclose(result.curve.Knot(i), kink_param, rel_tol=1e-4):
@@ -230,7 +245,7 @@ class TestBSplineApproxInterp:
         poles.SetValue(1, gp_Pnt(0, 0, 0))
         poles.SetValue(2, gp_Pnt(2, 0, 0))
         knots = BSplineAlgorithms.to_array([0.0, 1.0])
-        mults = BSplineAlgorithms.to_array_int([2, 2]) # Degree 1, clamped
+        mults = BSplineAlgorithms.to_array_int([2, 2])  # Degree 1, clamped
         curve = Geom_BSplineCurve(poles, knots.Array1(), mults.Array1(), 1)
 
         # Test point on the curve
@@ -245,9 +260,14 @@ class TestBSplineApproxInterp:
         pnt_off_curve = gp_Pnt(1, 1, 0)
         initial_param_off = 0.5
         res_off = interp._project_on_curve(pnt_off_curve, curve, initial_param_off)
-        assert math.isclose(res_off.parameter, 0.5, rel_tol=1e-6) # Closest point is at 0.5
-        assert math.isclose(res_off.error, 1.0, rel_tol=1e-6) # Distance to (1,0,0) is 1.0
+        assert math.isclose(
+            res_off.parameter, 0.5, rel_tol=1e-6
+        )  # Closest point is at 0.5
+        assert math.isclose(
+            res_off.error, 1.0, rel_tol=1e-6
+        )  # Distance to (1,0,0) is 1.0
+
 
 if __name__ == "__main__":
     # pytest.main([f'{__file__}::TestBSplineApproxInterp::test_fit_curve_with_kinks', "-v"])
-    pytest.main([f'{__file__}', "-v"])
+    pytest.main([f"{__file__}", "-v"])

--- a/tests/test_curve_network_sorter.py
+++ b/tests/test_curve_network_sorter.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from typing import List, Tuple
 
 import numpy as np
@@ -9,12 +7,9 @@ from OCP.gp import gp_Pnt
 from OCP.TColgp import TColgp_Array1OfPnt
 from OCP.TColStd import TColStd_Array1OfInteger, TColStd_Array1OfReal
 
-# Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
 # Import the CurveNetworkSorter from the internal module
-from src_py.ocp_gordon.internal.curve_network_sorter import CurveNetworkSorter
-from src_py.ocp_gordon.internal.error import error
+from ocp_gordon.internal.curve_network_sorter import CurveNetworkSorter
+from ocp_gordon.internal.error import error
 
 
 def create_linear_bspline_curve(

--- a/tests/test_curves_to_surface.py
+++ b/tests/test_curves_to_surface.py
@@ -1,6 +1,4 @@
 import pytest
-import sys
-import os
 import numpy as np
 
 from OCP.gp import gp_Pnt
@@ -9,12 +7,10 @@ from OCP.TColStd import TColStd_Array1OfReal, TColStd_Array1OfInteger
 from OCP.Geom import Geom_BSplineCurve, Geom_BSplineSurface
 from OCP.GeomConvert import GeomConvert
 
-# Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from ocp_gordon.internal.curves_to_surface import CurvesToSurface, clamp_bspline
+from ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms
+from ocp_gordon.internal.error import ErrorCode, error
 
-from src_py.ocp_gordon.internal.curves_to_surface import CurvesToSurface, clamp_bspline
-from src_py.ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms
-from src_py.ocp_gordon.internal.error import ErrorCode, error
 
 # Helper to create a simple B-spline curve for testing
 @pytest.fixture
@@ -24,7 +20,7 @@ def create_test_bspline_curve():
         for i, p_data in enumerate(poles_data, 1):
             poles.SetValue(i, gp_Pnt(p_data[0], p_data[1], p_data[2]))
 
-        num_poles = len(poles_data) # This is the number of poles for the OCP object
+        num_poles = len(poles_data)  # This is the number of poles for the OCP object
 
         if periodic:
             # For periodic B-splines, the knot vector is typically uniform
@@ -38,7 +34,7 @@ def create_test_bspline_curve():
             for i in range(1, num_knots_periodic + 1):
                 knots_array.SetValue(i, float(i - 1))
                 mults_array.SetValue(i, 1)
-            
+
             # No need for unique_knots adjustment for uniform periodic knots
             final_knots = knots_array
             final_mults = mults_array
@@ -47,10 +43,10 @@ def create_test_bspline_curve():
             # For a clamped B-spline, the knot vector structure is well-defined.
             # The sum of multiplicities must be equal to num_poles + degree + 1.
             # The first and last knots have a multiplicity of degree + 1.
-            
+
             num_internal_knots = num_poles - degree - 1
             num_unique_knots = num_internal_knots + 2
-            
+
             final_knots = TColStd_Array1OfReal(1, num_unique_knots)
             final_mults = TColStd_Array1OfInteger(1, num_unique_knots)
 
@@ -69,39 +65,52 @@ def create_test_bspline_curve():
             final_mults.SetValue(num_unique_knots, degree + 1)
 
         return Geom_BSplineCurve(poles, final_knots, final_mults, degree, periodic)
+
     return _create_test_bspline_curve
+
 
 def test_clamp_bspline(create_test_bspline_curve):
     # Create a periodic B-spline curve
     poles_data = [
-        (0, 0, 0), (1, 1, 0), (2, 0, 0), (1, -1, 0), (0, 0, 0) # Closed shape
+        (0, 0, 0),
+        (1, 1, 0),
+        (2, 0, 0),
+        (1, -1, 0),
+        (0, 0, 0),  # Closed shape
     ]
     degree = 2
     # poles_data = poles_data[:-1]
     periodic_curve = create_test_bspline_curve(poles_data, degree, periodic=True)
-    
+
     assert periodic_curve.IsPeriodic()
 
     clamped_curve = clamp_bspline(periodic_curve)
-    
+
     assert clamped_curve is not None
     assert not clamped_curve.IsPeriodic()
     # Check if the clamped curve still represents the original shape within its parameter range
-    assert clamped_curve.FirstParameter() == pytest.approx(periodic_curve.FirstParameter())
-    assert clamped_curve.LastParameter() == pytest.approx(periodic_curve.LastParameter())
+    assert clamped_curve.FirstParameter() == pytest.approx(
+        periodic_curve.FirstParameter()
+    )
+    assert clamped_curve.LastParameter() == pytest.approx(
+        periodic_curve.LastParameter()
+    )
 
     # Test with a non-periodic curve (should return None or the same curve)
-    non_periodic_curve = create_test_bspline_curve(poles_data[:-1], degree, periodic=False)
+    non_periodic_curve = create_test_bspline_curve(
+        poles_data[:-1], degree, periodic=False
+    )
     assert not non_periodic_curve.IsPeriodic()
     result = clamp_bspline(non_periodic_curve)
-    assert result is None # clamp_bspline returns None if not periodic
+    assert result is None  # clamp_bspline returns None if not periodic
+
 
 def test_curves_to_surface_basic(create_test_bspline_curve):
     # Create a simple network of curves
     # Two profile curves (u-direction)
     curve1_poles = [(0, 0, 0), (1, 0, 0), (2, 0, 0)]
     curve2_poles = [(0, 1, 1), (1, 1, 1), (2, 1, 1)]
-    degree = 1 # Linear curves for simplicity
+    degree = 1  # Linear curves for simplicity
 
     curve1 = create_test_bspline_curve(curve1_poles, degree)
     curve2 = create_test_bspline_curve(curve2_poles, degree)
@@ -115,14 +124,14 @@ def test_curves_to_surface_basic(create_test_bspline_curve):
     assert isinstance(surface, Geom_BSplineSurface)
     assert surface.NbUPoles() > 0
     assert surface.NbVPoles() > 0
-    
+
     # Check degrees
     assert surface.UDegree() == degree
     # V-degree should be max_degree (default 3) or adjusted based on interpolation
-    assert surface.VDegree() >= 1 
+    assert surface.VDegree() >= 1
 
     # Test with explicit parameters
-    explicit_params = [0.0, 1.0] # Corresponding to the two curves
+    explicit_params = [0.0, 1.0]  # Corresponding to the two curves
     skinner_explicit = CurvesToSurface(curves, parameters=explicit_params)
     surface_explicit = skinner_explicit.surface()
 
@@ -132,26 +141,32 @@ def test_curves_to_surface_basic(create_test_bspline_curve):
     assert skinner_explicit.get_parameters() == explicit_params
 
     u_first, u_last, v_first, v_last = surface_explicit.Bounds()
-    tolerance = 1e-4   
+    tolerance = 1e-4
 
     # def get_point(p: gp_Pnt):
     #     return [p.X(), p.Y(), p.Z()]
-    
+
     # u1 = u_last
     # v1 = v_first
     # print(f'gordon_surface({u1}, {v1})={get_point(gordon_surface.Value(u1, v1))}')
     # print(f'profile1({0})={get_point(profile1.Value(0))}')
 
     # Let's check the corner points more reliably.
-    assert surface_explicit.Value(u_first, v_first).IsEqual(curve1.Value(0.0), tolerance)
+    assert surface_explicit.Value(u_first, v_first).IsEqual(
+        curve1.Value(0.0), tolerance
+    )
     assert surface_explicit.Value(u_last, v_first).IsEqual(curve1.Value(1.0), tolerance)
     assert surface_explicit.Value(u_first, v_last).IsEqual(curve2.Value(0.0), tolerance)
     assert surface_explicit.Value(u_last, v_last).IsEqual(curve2.Value(1.0), tolerance)
 
+
 def test_curves_to_surface_empty_input():
-    with pytest.raises(RuntimeError): # Should raise RuntimeError from surface() if no curves
+    with pytest.raises(
+        RuntimeError
+    ):  # Should raise RuntimeError from surface() if no curves
         skinner = CurvesToSurface([])
         skinner.surface()
+
 
 def test_set_max_degree(create_test_bspline_curve):
     # With only two curves, the interpolation in V will always be degree 1
@@ -163,7 +178,7 @@ def test_set_max_degree(create_test_bspline_curve):
     curves = [curve1, curve2]
 
     skinner = CurvesToSurface(curves)
-    
+
     # Default max_degree is 3, but with 2 curves, result is degree 1
     surface_default = skinner.surface()
     assert surface_default.VDegree() == 1
@@ -171,7 +186,9 @@ def test_set_max_degree(create_test_bspline_curve):
     skinner.invalidate()
     skinner.set_max_degree(2)
     surface_new_degree = skinner.surface()
-    assert surface_new_degree.VDegree() == 1 # Still 1, as it's limited by number of curves
+    assert (
+        surface_new_degree.VDegree() == 1
+    )  # Still 1, as it's limited by number of curves
 
     # Now test with enough curves to actually reach a higher degree
     curve3_poles = [(0, 2, 0), (1, 2, 0), (2, 2, 0)]
@@ -181,7 +198,7 @@ def test_set_max_degree(create_test_bspline_curve):
     curves_more = [curve1, curve2, curve3, curve4]
 
     skinner_more = CurvesToSurface(curves_more)
-    
+
     # Default max_degree is 3, and with 4 curves, it should reach degree 3
     surface_default_more = skinner_more.surface()
     assert surface_default_more.VDegree() == 3
@@ -189,17 +206,18 @@ def test_set_max_degree(create_test_bspline_curve):
     skinner_more.invalidate()
     skinner_more.set_max_degree(2)
     surface_new_degree_more = skinner_more.surface()
-    assert surface_new_degree_more.VDegree() == 2 # Should now be 2
+    assert surface_new_degree_more.VDegree() == 2  # Should now be 2
 
     with pytest.raises(ValueError):
         skinner.set_max_degree(0)
+
 
 def test_curves_to_surface_closed_continuity(create_test_bspline_curve):
     # Create curves that form a closed loop in the v-direction
     # e.g., curve1 and curve3 are the same
     curve1_poles = [(0, 0, 0), (1, 0, 0), (2, 0, 0)]
     curve2_poles = [(0, 1, 1), (1, 1, 1), (2, 1, 1)]
-    curve3_poles = [(0, 0, 0), (1, 0, 0), (2, 0, 0)] # Same as curve1
+    curve3_poles = [(0, 0, 0), (1, 0, 0), (2, 0, 0)]  # Same as curve1
     degree = 1
 
     curve1 = create_test_bspline_curve(curve1_poles, degree)
@@ -217,6 +235,7 @@ def test_curves_to_surface_closed_continuity(create_test_bspline_curve):
     # but this is complex to verify purely from OCP object properties.
     # We can at least check if the surface was created without error.
 
+
 def test_curves_to_surface_parameter_mismatch(create_test_bspline_curve):
     curve1_poles = [(0, 0, 0), (1, 0, 0), (2, 0, 0)]
     curve2_poles = [(0, 1, 1), (1, 1, 1), (2, 1, 1)]
@@ -226,9 +245,13 @@ def test_curves_to_surface_parameter_mismatch(create_test_bspline_curve):
     curves = [curve1, curve2]
 
     # Provide wrong number of parameters
-    with pytest.raises(Exception, match="The amount of given parameters has to be equal to the amount of given B-splines!"):
+    with pytest.raises(
+        Exception,
+        match="The amount of given parameters has to be equal to the amount of given B-splines!",
+    ):
         skinner = CurvesToSurface(curves, parameters=[0.0])
         skinner.surface()
+
 
 def test_curves_to_surface_non_bspline_input():
     # This test assumes GeomConvert.CurveToBSplineCurve_s handles generic Geom_Curve
@@ -239,8 +262,9 @@ def test_curves_to_surface_non_bspline_input():
     # are populated by `GeomConvert.CurveToBSplineCurve_s`.
     pass
 
+
 if __name__ == "__main__":
     if 0:
-        pytest.main([f'{__file__}::test_set_max_degree', "-v"])
+        pytest.main([f"{__file__}::test_set_max_degree", "-v"])
     else:
-        pytest.main([f'{__file__}', "-v"])
+        pytest.main([f"{__file__}", "-v"])

--- a/tests/test_gordon_surface_builder.py
+++ b/tests/test_gordon_surface_builder.py
@@ -1,41 +1,39 @@
 import pytest
-import sys
-import os
 import numpy as np
-from typing import List # Import List
+from typing import List  # Import List
 
 from OCP.gp import gp_Pnt
 from OCP.TColgp import TColgp_Array1OfPnt
 from OCP.TColStd import TColStd_Array1OfReal, TColStd_Array1OfInteger
 from OCP.Geom import Geom_BSplineCurve, Geom_BSplineSurface
 
-# Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from ocp_gordon.internal.gordon_surface_builder import GordonSurfaceBuilder
+from ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms, SurfaceDirection
+from ocp_gordon.internal.error import error, ErrorCode
 
-from src_py.ocp_gordon.internal.gordon_surface_builder import GordonSurfaceBuilder
-from src_py.ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms, SurfaceDirection
-from src_py.ocp_gordon.internal.error import error, ErrorCode
 
 # Helper function to create a simple B-spline curve
-def create_simple_bspline_curve(points: list[gp_Pnt], degree: int = 3) -> Geom_BSplineCurve:
+def create_simple_bspline_curve(
+    points: list[gp_Pnt], degree: int = 3
+) -> Geom_BSplineCurve:
     num_poles = len(points)
-    
+
     # Control points
     poles_array = TColgp_Array1OfPnt(1, num_poles)
     for i, pnt in enumerate(points, 1):
         poles_array.SetValue(i, pnt)
-    
+
     # For a clamped B-spline, the knot vector structure is well-defined.
     # The sum of multiplicities must be equal to num_poles + degree + 1.
     # The first and last knots have a multiplicity of degree + 1.
-    
+
     # Calculate number of internal knots
     # num_poles = n+1, degree = p. Sum of mults = n+p+2.
     # Number of unique knots = n-p+2.
     # If num_poles = 3, degree = 1: num_internal_knots = 3 - 1 - 1 = 1. num_unique_knots = 1 + 2 = 3.
     # Knots: {0, 0, 0.5, 1, 1} for degree 1. Unique knots: {0, 0.5, 1}.
     # Multiplicities: {2, 1, 2}.
-    
+
     # The number of unique knots is num_poles - degree + 1.
     # This is derived from the formula: num_poles = num_unique_knots + degree - sum(internal_mults)
     # For clamped, sum(internal_mults) = num_internal_knots.
@@ -43,7 +41,7 @@ def create_simple_bspline_curve(points: list[gp_Pnt], degree: int = 3) -> Geom_B
     # num_unique_knots = num_poles - degree + num_internal_knots.
     # num_internal_knots = num_poles - degree - 1 (if internal mults are 1)
     # num_unique_knots = (num_poles - degree - 1) + 2 (for start and end knots)
-    
+
     if num_poles <= degree:
         # Not enough poles for the given degree to form a proper B-spline
         # This case should ideally be handled by the calling code or result in an error.
@@ -51,8 +49,10 @@ def create_simple_bspline_curve(points: list[gp_Pnt], degree: int = 3) -> Geom_B
         raise ValueError(f"Insufficient poles ({num_poles}) for degree ({degree})")
 
     num_internal_knots = num_poles - degree - 1
-    num_unique_knots = num_internal_knots + 2 # Number of unique knots (including 0 and 1)
-    
+    num_unique_knots = (
+        num_internal_knots + 2
+    )  # Number of unique knots (including 0 and 1)
+
     final_knots = TColStd_Array1OfReal(1, num_unique_knots)
     final_mults = TColStd_Array1OfInteger(1, num_unique_knots)
 
@@ -70,7 +70,9 @@ def create_simple_bspline_curve(points: list[gp_Pnt], degree: int = 3) -> Geom_B
     final_knots.SetValue(num_unique_knots, 1.0)
     final_mults.SetValue(num_unique_knots, degree + 1)
 
-    return Geom_BSplineCurve(poles_array, final_knots, final_mults, degree, False) # Not periodic
+    return Geom_BSplineCurve(
+        poles_array, final_knots, final_mults, degree, False
+    )  # Not periodic
 
 
 def test_gordon_surface_builder_basic_construction():
@@ -93,8 +95,16 @@ def test_gordon_surface_builder_basic_construction():
     # guide2_points = [gp_Pnt(1, 0.5, 0), gp_Pnt(1, 1.5, 1), gp_Pnt(1, 2.5, 2)]
     # guide3_points = [gp_Pnt(2, 0, 0), gp_Pnt(2, 1, 1), gp_Pnt(2, 2, 2)]
     guide1_points = [gp_Pnt(0, 0, 0), gp_Pnt(0, 1, 1), gp_Pnt(0, 2, 2)]
-    guide2_points = [gp_Pnt(2.0/3, 0, 0), gp_Pnt(2.0/3, 1, 1), gp_Pnt(2.0/3, 2, 2)]
-    guide3_points = [gp_Pnt(4.0/3, 0, 0), gp_Pnt(4.0/3, 1, 1), gp_Pnt(4.0/3, 2, 2)]
+    guide2_points = [
+        gp_Pnt(2.0 / 3, 0, 0),
+        gp_Pnt(2.0 / 3, 1, 1),
+        gp_Pnt(2.0 / 3, 2, 2),
+    ]
+    guide3_points = [
+        gp_Pnt(4.0 / 3, 0, 0),
+        gp_Pnt(4.0 / 3, 1, 1),
+        gp_Pnt(4.0 / 3, 2, 2),
+    ]
     guide4_points = [gp_Pnt(2, 0, 0), gp_Pnt(2, 1, 1), gp_Pnt(2, 2, 2)]
 
     guide1 = create_simple_bspline_curve(guide1_points, degree=1)
@@ -106,15 +116,18 @@ def test_gordon_surface_builder_basic_construction():
     # Intersection parameters (normalized 0 to 1)
     # These should represent the parameter values on each curve where they intersect.
     # For simple linear curves, these might be evenly spaced.
-    intersection_params_u = [0.0, 1.0/3, 2.0/3, 1.0] # Parameters along profiles (u-direction)
-    intersection_params_v = [0.0, 0.5, 1.0] # Parameters along guides (v-direction)
+    intersection_params_u = [
+        0.0,
+        1.0 / 3,
+        2.0 / 3,
+        1.0,
+    ]  # Parameters along profiles (u-direction)
+    intersection_params_v = [0.0, 0.5, 1.0]  # Parameters along guides (v-direction)
 
     tolerance = 1e-6
 
     builder = GordonSurfaceBuilder(
-        profiles, guides,
-        intersection_params_u, intersection_params_v,
-        tolerance
+        profiles, guides, intersection_params_u, intersection_params_v, tolerance
     )
 
     builder.perform()
@@ -137,32 +150,35 @@ def test_gordon_surface_builder_basic_construction():
     # Verify interpolation at a few points (e.g., corners)
     # The Gordon surface should interpolate the original curve network.
     # For a simple linear network, the corner points should match.
-    
+
     # Point (0,0)
-    p00_expected = profile1.Value(intersection_params_u[0]) # Should be (0,0,0)
+    p00_expected = profile1.Value(intersection_params_u[0])  # Should be (0,0,0)
     u_first, u_last, v_first, v_last = gordon_surface.Bounds()
     p00_actual = gordon_surface.Value(u_first, v_first)
     assert p00_actual.IsEqual(p00_expected, tolerance)
 
     # Point (1,1) - middle intersection
-    p11_expected = profile2.Value(intersection_params_u[1]) # Should be (1, 1.5, 1)
-    p11_actual = gordon_surface.Value(u_first + (u_last - u_first) * 0.5,
-                                      v_first + (v_last - v_first) * 0.5)
+    p11_expected = profile2.Value(intersection_params_u[1])  # Should be (1, 1.5, 1)
+    p11_actual = gordon_surface.Value(
+        u_first + (u_last - u_first) * 0.5, v_first + (v_last - v_first) * 0.5
+    )
     # assert p11_actual.IsEqual(p11_expected, tolerance)
     # Note: The actual parameter values for the middle point might not be exactly 0.5 on the surface
     # due to reparameterization and knot insertion. We need to evaluate at the corresponding
     # parameter values on the surface. For now, let's use the middle of the surface parameter range.
     # A more robust test would involve mapping the original curve parameters to the surface parameters.
     # For degree 1 curves, the parameter range is usually 0 to 1.
-    
+
     # Let's check the corner points more reliably.
     # (u=0, v=0) -> profile1.Value(0.0) -> guide1.Value(0.0)
-    assert gordon_surface.Value(u_first, v_first).IsEqual(profile1.Value(0.0), tolerance)
+    assert gordon_surface.Value(u_first, v_first).IsEqual(
+        profile1.Value(0.0), tolerance
+    )
     assert gordon_surface.Value(u_first, v_first).IsEqual(guide1.Value(0.0), tolerance)
 
     # def get_point(p: gp_Pnt):
     #     return [p.X(), p.Y(), p.Z()]
-    
+
     # u1 = u_last
     # v1 = v_first
     # print(f'gordon_surface({u1}, {v1})={get_point(gordon_surface.Value(u1, v1))}')
@@ -180,30 +196,42 @@ def test_gordon_surface_builder_basic_construction():
     # print(f'surf_guides.Poles()={get_point(surf_guides.Poles()(2,2))}')
     # print(f'surf_intersections.Poles()={get_point(surf_intersections.Poles()(2,2))}')
 
-    # (u=1, v=0) -> profile1.Value(1.0) -> guide3.Value(0.0)    
+    # (u=1, v=0) -> profile1.Value(1.0) -> guide3.Value(0.0)
     # assert surf_profiles.Value(u_last, v_first).IsEqual(profiles[0].Value(1.0), tolerance)
     # assert surf_guides.Value(u_last, v_first).IsEqual(guides[0].Value(1.0), tolerance)
     # assert surf_intersections.Value(u_last, v_first).IsEqual(profiles[0].Value(1.0), tolerance)
-    assert gordon_surface.Value(u_last, v_first).IsEqual(profiles[0].Value(1.0), tolerance)
-    assert gordon_surface.Value(u_last, v_first).IsEqual(guides[-1].Value(0.0), tolerance)
+    assert gordon_surface.Value(u_last, v_first).IsEqual(
+        profiles[0].Value(1.0), tolerance
+    )
+    assert gordon_surface.Value(u_last, v_first).IsEqual(
+        guides[-1].Value(0.0), tolerance
+    )
 
     # (u=0, v=1) -> profile3.Value(0.0) -> guide1.Value(1.0)
-    assert gordon_surface.Value(u_first, v_last).IsEqual(profiles[-1].Value(0.0), tolerance)
-    assert gordon_surface.Value(u_first, v_last).IsEqual(guides[0].Value(1.0), tolerance)
+    assert gordon_surface.Value(u_first, v_last).IsEqual(
+        profiles[-1].Value(0.0), tolerance
+    )
+    assert gordon_surface.Value(u_first, v_last).IsEqual(
+        guides[0].Value(1.0), tolerance
+    )
 
     # (u=1, v=1) -> profile3.Value(1.0) -> guide3.Value(1.0)
-    assert gordon_surface.Value(u_last, v_last).IsEqual(profiles[-1].Value(1.0), tolerance)
-    assert gordon_surface.Value(u_last, v_last).IsEqual(guides[-1].Value(1.0), tolerance)
+    assert gordon_surface.Value(u_last, v_last).IsEqual(
+        profiles[-1].Value(1.0), tolerance
+    )
+    assert gordon_surface.Value(u_last, v_last).IsEqual(
+        guides[-1].Value(1.0), tolerance
+    )
 
 
 def test_gordon_surface_builder_insufficient_curves():
     profile1_points = [gp_Pnt(0, 0, 0), gp_Pnt(1, 0.5, 0), gp_Pnt(2, 0, 0)]
     profile1 = create_simple_bspline_curve(profile1_points, degree=1)
-    profiles = [profile1] # Only one profile
+    profiles = [profile1]  # Only one profile
 
     guide1_points = [gp_Pnt(0, 0, 0), gp_Pnt(0, 1, 1), gp_Pnt(0, 2, 2)]
     guide1 = create_simple_bspline_curve(guide1_points, degree=1)
-    guides = [guide1] # Only one guide
+    guides = [guide1]  # Only one guide
 
     intersection_params_u = [0.0, 1.0]
     intersection_params_v = [0.0, 1.0]
@@ -212,30 +240,36 @@ def test_gordon_surface_builder_insufficient_curves():
     # Test with insufficient profiles
     with pytest.raises(error) as excinfo:
         builder = GordonSurfaceBuilder(
-            profiles, guides,
-            intersection_params_u, intersection_params_v,
-            tolerance
+            profiles, guides, intersection_params_u, intersection_params_v, tolerance
         )
         builder.perform()
     assert "There must be at least two profiles" in str(excinfo.value)
-    assert excinfo.value.get_code() == ErrorCode.MATH_ERROR # Changed ._code to .get_code()
+    assert (
+        excinfo.value.get_code() == ErrorCode.MATH_ERROR
+    )  # Changed ._code to .get_code()
 
     # Test with insufficient guides (reset profiles to valid count)
-    profiles = [profile1, create_simple_bspline_curve([gp_Pnt(0,0,0), gp_Pnt(1,1,1)], degree=1)]
-    guides = [guide1] # Only one guide
+    profiles = [
+        profile1,
+        create_simple_bspline_curve([gp_Pnt(0, 0, 0), gp_Pnt(1, 1, 1)], degree=1),
+    ]
+    guides = [guide1]  # Only one guide
 
     with pytest.raises(error) as excinfo:
         builder = GordonSurfaceBuilder(
-            profiles, guides,
-            intersection_params_u, intersection_params_v,
-            tolerance
+            profiles, guides, intersection_params_u, intersection_params_v, tolerance
         )
         builder.perform()
     assert "There must be at least two guides" in str(excinfo.value)
-    assert excinfo.value.get_code() == ErrorCode.MATH_ERROR # Changed ._code to .get_code()
+    assert (
+        excinfo.value.get_code() == ErrorCode.MATH_ERROR
+    )  # Changed ._code to .get_code()
+
 
 if __name__ == "__main__":
     if 0:
-        pytest.main([f'{__file__}::test_gordon_surface_builder_basic_construction', "-v"])
+        pytest.main(
+            [f"{__file__}::test_gordon_surface_builder_basic_construction", "-v"]
+        )
     else:
-        pytest.main([f'{__file__}', "-v"])
+        pytest.main([f"{__file__}", "-v"])

--- a/tests/test_interpolate_curve_network.py
+++ b/tests/test_interpolate_curve_network.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from typing import List  # Import List
 
 import numpy as np
@@ -14,15 +12,12 @@ from OCP.Precision import Precision
 from OCP.TColgp import TColgp_Array1OfPnt, TColgp_HArray1OfPnt
 from OCP.TColStd import TColStd_Array1OfInteger, TColStd_Array1OfReal
 
-# Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
 # Import actual internal dependencies
-from src_py.ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms
-from src_py.ocp_gordon.internal.curve_network_sorter import CurveNetworkSorter
-from src_py.ocp_gordon.internal.error import ErrorCode, error
-from src_py.ocp_gordon.internal.gordon_surface_builder import GordonSurfaceBuilder
-from src_py.ocp_gordon.internal.interpolate_curve_network import (
+from ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms
+from ocp_gordon.internal.curve_network_sorter import CurveNetworkSorter
+from ocp_gordon.internal.error import ErrorCode, error
+from ocp_gordon.internal.gordon_surface_builder import GordonSurfaceBuilder
+from ocp_gordon.internal.interpolate_curve_network import (
     CompatibilityError,
     InterpolateCurveNetwork,
     IntersectionError,
@@ -30,8 +25,8 @@ from src_py.ocp_gordon.internal.interpolate_curve_network import (
     SurfaceConstructionError,
     interpolate_curve_network,
 )
-from src_py.ocp_gordon.internal.intersect_bsplines import IntersectBSplines
-from src_py.ocp_gordon.internal.misc import (
+from ocp_gordon.internal.intersect_bsplines import IntersectBSplines
+from ocp_gordon.internal.misc import (
     concat_two_bsplines,
     load_bsplines_from_object,
     save_bsplines_to_file,

--- a/tests/test_intersect_bsplines.py
+++ b/tests/test_intersect_bsplines.py
@@ -6,8 +6,6 @@ using recursive subdivision and optimization methods.
 """
 
 import math
-import os
-import sys
 
 import numpy as np
 import pytest
@@ -18,17 +16,14 @@ from OCP.GeomConvert import GeomConvert
 from OCP.gp import gp_Ax1, gp_Ax2, gp_Dir, gp_Pnt, gp_Trsf
 from OCP.TColgp import TColgp_Array1OfPnt
 
-# Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
 # Import the module to test
-from src_py.ocp_gordon.internal.intersect_bsplines import (
+from ocp_gordon.internal.intersect_bsplines import (
     BoundingBox,
     IntersectBSplines,
     is_point_on_line_segment,
     line_line_intersection_3d,
 )
-from src_py.ocp_gordon.internal.misc import (
+from ocp_gordon.internal.misc import (
     clone_bspline,
     load_bsplines_from_object,
     save_bsplines_to_file,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,7 +1,5 @@
 import numpy as np
 import pytest
-import sys
-import os
 import math
 
 from OCP.gp import gp_Pnt, gp_Vec, gp_XYZ
@@ -9,10 +7,13 @@ from OCP.Geom import Geom_Curve, Geom_BSplineCurve
 from OCP.TColgp import TColgp_Array1OfPnt
 from OCP.GeomAPI import GeomAPI_PointsToBSpline
 
-# Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from ocp_gordon.internal.misc import (
+    math_Vector,
+    Standard_Real,
+    math_MultipleVarFunctionWithGradient,
+    math_BFGS,
+)
 
-from src_py.ocp_gordon.internal.misc import math_Vector, Standard_Real, math_MultipleVarFunctionWithGradient, math_BFGS
 
 class CurveCurveDistanceObjectiveArcTan(math_MultipleVarFunctionWithGradient):
     def __init__(self, c1: Geom_Curve, c2: Geom_Curve):
@@ -27,10 +28,12 @@ class CurveCurveDistanceObjectiveArcTan(math_MultipleVarFunctionWithGradient):
     def Value(self, X: math_Vector, F: Standard_Real) -> bool:
         G = math_Vector(1, 2)
         self.Values(X, F, G)
-        return True # The original C++ returns true, and F is an output parameter
+        return True  # The original C++ returns true, and F is an output parameter
 
-    def Gradient(self, X: math_Vector, G: math_Vector) -> bool: # Gradient also takes G as an output parameter
-        F_val = Standard_Real(0.0) # Create a temporary Standard_Real for F
+    def Gradient(
+        self, X: math_Vector, G: math_Vector
+    ) -> bool:  # Gradient also takes G as an output parameter
+        F_val = Standard_Real(0.0)  # Create a temporary Standard_Real for F
         self.Values(X, F_val, G)
         return True
 
@@ -44,11 +47,11 @@ class CurveCurveDistanceObjectiveArcTan(math_MultipleVarFunctionWithGradient):
 
     @staticmethod
     def activate(z: float) -> float:
-        return z #0.6 * math.sin(z) + 0.5
+        return z  # 0.6 * math.sin(z) + 0.5
 
     @staticmethod
     def d_activate(z: float) -> float:
-        return 1 #0.6 * math.cos(z)
+        return 1  # 0.6 * math.cos(z)
 
     def getUParam(self, x0: float) -> float:
         umin = self.m_c1.FirstParameter()
@@ -74,21 +77,34 @@ class CurveCurveDistanceObjectiveArcTan(math_MultipleVarFunctionWithGradient):
         u = self.getUParam(X.Value(1))
         v = self.getVParam(X.Value(2))
 
-        p1 = gp_Pnt(0,0,0)
-        p2 = gp_Pnt(0,0,0)
-        d1_vec = gp_Vec(0,0,0)
-        d2_vec = gp_Vec(0,0,0)
+        p1 = gp_Pnt(0, 0, 0)
+        p2 = gp_Pnt(0, 0, 0)
+        d1_vec = gp_Vec(0, 0, 0)
+        d2_vec = gp_Vec(0, 0, 0)
 
         self.m_c1.D1(u, p1, d1_vec)
         self.m_c2.D1(v, p2, d2_vec)
 
         diff = gp_Vec(p1.X() - p2.X(), p1.Y() - p2.Y(), p1.Z() - p2.Z())
         F.value = diff.SquareMagnitude()
-        
-        G.SetValue(1, 2. * diff.Dot(d1_vec) * (self.m_c1.LastParameter() - self.m_c1.FirstParameter()) * self.d_getUParam(X.Value(1)))
-        G.SetValue(2, -2. * diff.Dot(d2_vec) * (self.m_c2.LastParameter() - self.m_c2.FirstParameter()) * self.d_getVParam(X.Value(2)))
+
+        G.SetValue(
+            1,
+            2.0
+            * diff.Dot(d1_vec)
+            * (self.m_c1.LastParameter() - self.m_c1.FirstParameter())
+            * self.d_getUParam(X.Value(1)),
+        )
+        G.SetValue(
+            2,
+            -2.0
+            * diff.Dot(d2_vec)
+            * (self.m_c2.LastParameter() - self.m_c2.FirstParameter())
+            * self.d_getVParam(X.Value(2)),
+        )
 
         return True
+
 
 class CurveCurveDistanceObjective(math_MultipleVarFunctionWithGradient):
     def __init__(self, c1: Geom_Curve, c2: Geom_Curve):
@@ -103,16 +119,18 @@ class CurveCurveDistanceObjective(math_MultipleVarFunctionWithGradient):
     def Value(self, X: math_Vector, F: Standard_Real) -> bool:
         G = math_Vector(1, 2)
         self.Values(X, F, G)
-        return True # The original C++ returns true, and F is an output parameter
+        return True  # The original C++ returns true, and F is an output parameter
 
-    def Gradient(self, X: math_Vector, G: math_Vector) -> bool: # Gradient also takes G as an output parameter
-        F_val = Standard_Real(0.0) # Create a temporary Standard_Real for F
+    def Gradient(
+        self, X: math_Vector, G: math_Vector
+    ) -> bool:  # Gradient also takes G as an output parameter
+        F_val = Standard_Real(0.0)  # Create a temporary Standard_Real for F
         self.Values(X, F_val, G)
         return True
 
     @staticmethod
     def activate(z: float) -> float:
-        return 0.5 * (math.sin(z) + 1.)
+        return 0.5 * (math.sin(z) + 1.0)
 
     @staticmethod
     def d_activate(z: float) -> float:
@@ -142,22 +160,35 @@ class CurveCurveDistanceObjective(math_MultipleVarFunctionWithGradient):
         u = self.getUParam(X.Value(1))
         v = self.getVParam(X.Value(2))
 
-        p1 = gp_Pnt(0,0,0)
-        p2 = gp_Pnt(0,0,0)
-        d1_vec = gp_Vec(0,0,0)
-        d2_vec = gp_Vec(0,0,0)
+        p1 = gp_Pnt(0, 0, 0)
+        p2 = gp_Pnt(0, 0, 0)
+        d1_vec = gp_Vec(0, 0, 0)
+        d2_vec = gp_Vec(0, 0, 0)
 
         self.m_c1.D1(u, p1, d1_vec)
         self.m_c2.D1(v, p2, d2_vec)
 
         diff = gp_Vec(p1.X() - p2.X(), p1.Y() - p2.Y(), p1.Z() - p2.Z())
         F.value = diff.SquareMagnitude()
-        
-        G.SetValue(1, 2. * diff.Dot(d1_vec) * (self.m_c1.LastParameter() - self.m_c1.FirstParameter()) * self.d_getUParam(X.Value(1)))
-        G.SetValue(2, -2. * diff.Dot(d2_vec) * (self.m_c2.LastParameter() - self.m_c2.FirstParameter()) * self.d_getVParam(X.Value(2)))
+
+        G.SetValue(
+            1,
+            2.0
+            * diff.Dot(d1_vec)
+            * (self.m_c1.LastParameter() - self.m_c1.FirstParameter())
+            * self.d_getUParam(X.Value(1)),
+        )
+        G.SetValue(
+            2,
+            -2.0
+            * diff.Dot(d2_vec)
+            * (self.m_c2.LastParameter() - self.m_c2.FirstParameter())
+            * self.d_getVParam(X.Value(2)),
+        )
 
         return True
-    
+
+
 class QuadraticFunction(math_MultipleVarFunctionWithGradient):
     def __init__(self):
         super().__init__()
@@ -179,90 +210,93 @@ class QuadraticFunction(math_MultipleVarFunctionWithGradient):
         # Gradient: grad_f(x, y) = [2x, 2y]
         G.SetValue(1, 2 * x)
         G.SetValue(2, 2 * y)
-        
+
         return True
+
 
 def create_bspline_curve(points: list[gp_Pnt]):
     """
     Create a B-spline curve from a list of points using GeomAPI_PointsToBSpline.
-    
+
     Args:
         points: List of gp_Pnt points
-        
+
     Returns:
         Handle(Geom_BSplineCurve): Approximated B-spline curve
     """
     # Create a regular array
     n_points = len(points)
     array = TColgp_Array1OfPnt(1, n_points)
-    
+
     # Fill the array with points (indexing starts at 1 in OCP)
     for i, point in enumerate(points, 1):
-            array.SetValue(i, point)
-    
+        array.SetValue(i, point)
+
     # Create the approximator with reasonable defaults
     # Parameters: points, min_degree, max_degree, continuity, tolerance
     approximator = GeomAPI_PointsToBSpline(array)
     return approximator.Curve()
 
+
 def create_test_curves():
     """
     Create test curves that form a proper intersecting network for Gordon surface interpolation.
-    
+
     Returns:
         Tuple of (profiles, guides) - lists of B-spline curves that properly intersect
     """
     profiles: list[Geom_BSplineCurve] = []
     guides: list[Geom_BSplineCurve] = []
-    
+
     # Define grid parameters
     num_profiles = 3
     num_guides = 4
     u_range = 8.0  # Range in u-direction (profiles)
     v_range = 5.0  # Range in v-direction (guides)
-    
+
     # Create intersection points grid
     # This defines where profiles and guides should intersect
     intersection_points = np.zeros((num_profiles, num_guides, 3))
-    
+
     for i in range(num_profiles):
         for j in range(num_guides):
             # Create a grid of points with some variation for a more interesting surface
             u = i * u_range / (num_profiles - 1) if num_profiles > 1 else 0
             v = j * v_range / (num_guides - 1) if num_guides > 1 else 0
-            
+
             # Add some 3D variation to make the surface more interesting
             z = 0.5 * np.sin(u * 0.5) * np.cos(v * 0.5)
-            
+
             intersection_points[i, j] = [u, v, z]
-    
+
     # Create profile curves (u-direction)
     for i in range(num_profiles):
         points: list[gp_Pnt] = []
-        
+
         # Each profile curve goes through all guide intersection points at this profile index
         for j in range(num_guides):
             x, y, z = intersection_points[i, j]
             points.append(gp_Pnt(x, y, z))
-        
+
         # Create B-spline curve through these points
         bspline_curve = create_bspline_curve(points)
         profiles.append(bspline_curve)
-    
+
     # Create guide curves (v-direction)
     for j in range(num_guides):
         points: list[gp_Pnt] = []
-        
+
         # Each guide curve goes through all profile intersection points at this guide index
         for i in range(num_profiles):
             x, y, z = intersection_points[i, j]
             points.append(gp_Pnt(x, y, z))
-        
+
         # Create B-spline curve through these points
         bspline_curve = create_bspline_curve(points)
         guides.append(bspline_curve)
-    
+
     return profiles, guides
+
 
 def test_math_bfgs_CurveCurveDistanceObjective():
     """
@@ -312,10 +346,12 @@ def test_math_bfgs_CurveCurveDistanceObjective():
 
     def get_point(p: gp_Pnt):
         return [p.X(), p.Y(), p.Z()]
-    
+
     u = func.getUParam(initial_x.Value(1))
     v = func.getVParam(initial_x.Value(2))
-    print(f'u={u}, v={v}, curve1({u})={get_point(curve1.Value(u))}, curve2({v})={get_point(curve2.Value(v))}')
+    print(
+        f"u={u}, v={v}, curve1({u})={get_point(curve1.Value(u))}, curve2({v})={get_point(curve2.Value(v))}"
+    )
     # assert False
 
     final_F = Standard_Real(0.0)
@@ -334,11 +370,14 @@ def test_math_bfgs_CurveCurveDistanceObjective():
     assert success, "Optimization should have succeeded"
     # assert abs(u) < 0.1, f"Final X[1] should be close to 0, got {u}"
     # assert abs(v) < 0.1, f"Final X[2] should be close to 0, got {v}"
-    
-    if success: # Only assert final F and G if optimization was successful
-        assert abs(final_F.value) < tolerance, f"Final F should be close to 0, got {final_F.value}"
+
+    if success:  # Only assert final F and G if optimization was successful
+        assert (
+            abs(final_F.value) < tolerance
+        ), f"Final F should be close to 0, got {final_F.value}"
         # assert abs(final_G.Value(1)) < tolerance, f"Final G[1] should be close to 0, got {final_G.Value(1)}"
         # assert abs(final_G.Value(2)) < tolerance, f"Final G[2] should be close to 0, got {final_G.Value(2)}"
+
 
 def test_math_bfgs_quadratic_function():
     """
@@ -383,17 +422,23 @@ def test_math_bfgs_quadratic_function():
         print(f"Final G: ({final_G.Value(1)}, {final_G.Value(2)})")
     # Assertions for pytest
     assert success, "Optimization should have succeeded"
-    assert abs(initial_x.Value(1)) < 0.1, f"Final X[1] should be close to 0, got {initial_x.Value(1)}"
-    assert abs(initial_x.Value(2)) < 0.1, f"Final X[2] should be close to 0, got {initial_x.Value(2)}"
-    
-    if success: # Only assert final F and G if optimization was successful
-        assert abs(final_F.value) < tolerance, f"Final F should be close to 0, got {final_F.value}"
+    assert (
+        abs(initial_x.Value(1)) < 0.1
+    ), f"Final X[1] should be close to 0, got {initial_x.Value(1)}"
+    assert (
+        abs(initial_x.Value(2)) < 0.1
+    ), f"Final X[2] should be close to 0, got {initial_x.Value(2)}"
+
+    if success:  # Only assert final F and G if optimization was successful
+        assert (
+            abs(final_F.value) < tolerance
+        ), f"Final F should be close to 0, got {final_F.value}"
         # assert abs(final_G.Value(1)) < tolerance, f"Final G[1] should be close to 0, got {final_G.Value(1)}"
         # assert abs(final_G.Value(2)) < tolerance, f"Final G[2] should be close to 0, got {final_G.Value(2)}"
 
 
 if __name__ == "__main__":
     if 0:
-        pytest.main([f'{__file__}::test_math_bfgs_CurveCurveDistanceObjective', "-v"])
+        pytest.main([f"{__file__}::test_math_bfgs_CurveCurveDistanceObjective", "-v"])
     else:
-        pytest.main([f'{__file__}', "-v"])
+        pytest.main([f"{__file__}", "-v"])

--- a/tests/test_points_to_bspline_interpolation.py
+++ b/tests/test_points_to_bspline_interpolation.py
@@ -1,23 +1,23 @@
 import pytest
-import sys
-import os
 import numpy as np
 from OCP.gp import gp_Pnt
 from OCP.TColgp import TColgp_HArray1OfPnt, TColgp_Array1OfPnt
 from OCP.Geom import Geom_BSplineCurve
 from OCP.TColStd import TColStd_Array1OfReal, TColStd_Array1OfInteger
 
-# Add the parent directory to the path to import the module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from ocp_gordon.internal.points_to_bspline_interpolation import (
+    PointsToBSplineInterpolation,
+)
+from ocp_gordon.internal.bspline_algorithms import (
+    BSplineAlgorithms,
+)  # Assuming BSplineAlgorithms is correctly implemented
 
-from src_py.ocp_gordon.internal.points_to_bspline_interpolation import PointsToBSplineInterpolation
-from src_py.ocp_gordon.internal.bspline_algorithms import BSplineAlgorithms # Assuming BSplineAlgorithms is correctly implemented
 
 # Helper function to create TColgp_HArray1OfPnt from a list of numpy arrays or gp_Pnt
 def create_occ_points(points_data: list) -> TColgp_HArray1OfPnt:
     if not points_data:
         raise ValueError("Points data cannot be empty.")
-    
+
     occ_array = TColgp_Array1OfPnt(1, len(points_data))
     for i, p in enumerate(points_data):
         if isinstance(p, gp_Pnt):
@@ -27,8 +27,11 @@ def create_occ_points(points_data: list) -> TColgp_HArray1OfPnt:
                 raise ValueError("Point data must have 3 coordinates (x, y, z).")
             occ_array.SetValue(i + 1, gp_Pnt(p[0], p[1], p[2]))
         else:
-            raise TypeError("Unsupported point data type. Must be gp_Pnt or list/tuple/ndarray.")
+            raise TypeError(
+                "Unsupported point data type. Must be gp_Pnt or list/tuple/ndarray."
+            )
     return TColgp_HArray1OfPnt(occ_array)
+
 
 class TestPointsToBSplineInterpolation:
 
@@ -59,7 +62,7 @@ class TestPointsToBSplineInterpolation:
         assert isinstance(curve, Geom_BSplineCurve)
         assert curve.Degree() == 1
         assert curve.NbPoles() == len(points_data)
-        
+
         # Check if the curve interpolates the points
         for i, p_data in enumerate(points_data):
             param = interpolator.m_params[i]
@@ -91,53 +94,56 @@ class TestPointsToBSplineInterpolation:
         # A square to test closed curve interpolation
         points_data = [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0, 0, 0]]
         occ_points = create_occ_points(points_data)
-        
+
         # For a closed curve, the last point is a duplicate of the first for interpolation purposes
         # The actual number of unique points is len(points_data) - 1
-        interpolator = PointsToBSplineInterpolation(occ_points, max_degree=3, continuous_if_closed=True)
+        interpolator = PointsToBSplineInterpolation(
+            occ_points, max_degree=3, continuous_if_closed=True
+        )
         curve = interpolator.curve()
 
         assert isinstance(curve, Geom_BSplineCurve)
         assert curve.IsClosed()
         assert interpolator.is_closed()
-        
+
         # For closed curves, the number of poles is typically NbPoints + Degree - 1 (for C2 continuity)
         # The algorithm removes the last parameter, so it's based on unique points.
         # Number of unique points = 4. Degree = 3. NbPoles = 5 + 3 - 1 = 7
         assert curve.NbPoles() == len(points_data) + interpolator.degree() - 1
 
         # Check if the curve interpolates the unique points
-        unique_points_data = points_data[:-1] # Exclude the last duplicate point
+        unique_points_data = points_data[:-1]  # Exclude the last duplicate point
         for i, p_data in enumerate(unique_points_data):
             param = interpolator.m_params[i]
             eval_pnt = curve.Value(param)
             assert np.isclose(eval_pnt.X(), p_data[0], atol=1e-6)
             assert np.isclose(eval_pnt.Y(), p_data[1], atol=1e-6)
             assert np.isclose(eval_pnt.Z(), p_data[2], atol=1e-6)
-        
+
         # Check the closing point
         eval_pnt_end = curve.Value(interpolator.m_params[-1])
         assert np.isclose(eval_pnt_end.X(), points_data[0][0], atol=1e-6)
         assert np.isclose(eval_pnt_end.Y(), points_data[0][1], atol=1e-6)
         assert np.isclose(eval_pnt_end.Z(), points_data[0][2], atol=1e-6)
 
-
     def test_degree_calculation(self):
         points_data = [[0, 0, 0], [1, 1, 0], [2, 0, 0], [3, 1, 0], [4, 0, 0]]
         occ_points = create_occ_points(points_data)
-        
+
         # Test with max_degree less than (num_points - 1)
         interpolator = PointsToBSplineInterpolation(occ_points, max_degree=2)
         assert interpolator.degree() == 2
 
         # Test with max_degree greater than or equal to (num_points - 1)
         interpolator = PointsToBSplineInterpolation(occ_points, max_degree=4)
-        assert interpolator.degree() == 4 # num_points - 1
+        assert interpolator.degree() == 4  # num_points - 1
 
         # Test with closed curve
         closed_points_data = [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0, 0, 0]]
         occ_closed_points = create_occ_points(closed_points_data)
-        interpolator_closed = PointsToBSplineInterpolation(occ_closed_points, max_degree=3, continuous_if_closed=True)
+        interpolator_closed = PointsToBSplineInterpolation(
+            occ_closed_points, max_degree=3, continuous_if_closed=True
+        )
         # For closed curves, max_degree is (num_unique_points - 1)
         # num_unique_points = 4, so max_degree = 3
         assert interpolator_closed.degree() == 3
@@ -152,46 +158,59 @@ class TestPointsToBSplineInterpolation:
         # Closed curve (first and last points are the same)
         closed_points_data = [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 0, 0]]
         occ_closed_points = create_occ_points(closed_points_data)
-        interpolator_closed = PointsToBSplineInterpolation(occ_closed_points, continuous_if_closed=True)
+        interpolator_closed = PointsToBSplineInterpolation(
+            occ_closed_points, continuous_if_closed=True
+        )
         assert interpolator_closed.is_closed()
 
         # Closed curve, but continuous_if_closed is False
-        interpolator_not_c2_closed = PointsToBSplineInterpolation(occ_closed_points, continuous_if_closed=False)
-        assert not interpolator_not_c2_closed.is_closed() # Should be false if C2 continuity is not enforced
+        interpolator_not_c2_closed = PointsToBSplineInterpolation(
+            occ_closed_points, continuous_if_closed=False
+        )
+        assert (
+            not interpolator_not_c2_closed.is_closed()
+        )  # Should be false if C2 continuity is not enforced
 
     def test_needs_shifting(self):
         # Open curve, degree 3 (odd)
         points_data = [[0, 0, 0], [1, 1, 0], [2, 0, 0], [3, 1, 0]]
         occ_points = create_occ_points(points_data)
         interpolator = PointsToBSplineInterpolation(occ_points, max_degree=3)
-        assert not interpolator.is_closed() # Not closed
+        assert not interpolator.is_closed()  # Not closed
         assert not interpolator.needs_shifting()
 
         # Closed curve, degree 3 (odd)
         closed_points_data = [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0, 0, 0]]
         occ_closed_points = create_occ_points(closed_points_data)
-        interpolator_closed_odd_degree = PointsToBSplineInterpolation(occ_closed_points, max_degree=3, continuous_if_closed=True)
+        interpolator_closed_odd_degree = PointsToBSplineInterpolation(
+            occ_closed_points, max_degree=3, continuous_if_closed=True
+        )
         assert interpolator_closed_odd_degree.is_closed()
-        assert interpolator_closed_odd_degree.degree() == 3 # Odd degree
+        assert interpolator_closed_odd_degree.degree() == 3  # Odd degree
         assert not interpolator_closed_odd_degree.needs_shifting()
 
         # Closed curve, degree 2 (even)
         # Need at least 3 unique points for degree 2
-        closed_points_data_even_degree = [[0,0,0], [1,0,0], [0.5,1,0], [0,0,0]]
-        occ_closed_points_even_degree = create_occ_points(closed_points_data_even_degree)
-        interpolator_closed_even_degree = PointsToBSplineInterpolation(occ_closed_points_even_degree, max_degree=2, continuous_if_closed=True)
+        closed_points_data_even_degree = [[0, 0, 0], [1, 0, 0], [0.5, 1, 0], [0, 0, 0]]
+        occ_closed_points_even_degree = create_occ_points(
+            closed_points_data_even_degree
+        )
+        interpolator_closed_even_degree = PointsToBSplineInterpolation(
+            occ_closed_points_even_degree, max_degree=2, continuous_if_closed=True
+        )
         assert interpolator_closed_even_degree.is_closed()
-        assert interpolator_closed_even_degree.degree() == 2 # Even degree
+        assert interpolator_closed_even_degree.degree() == 2  # Even degree
         assert interpolator_closed_even_degree.needs_shifting()
 
     def test_call_method(self):
         points_data = [[0, 0, 0], [1, 1, 0], [2, 0, 0]]
         occ_points = create_occ_points(points_data)
         interpolator = PointsToBSplineInterpolation(occ_points, max_degree=2)
-        curve = interpolator() # Using __call__
+        curve = interpolator()  # Using __call__
         assert isinstance(curve, Geom_BSplineCurve)
         assert curve.Degree() == 2
 
+
 if __name__ == "__main__":
     # pytest.main([f'{__file__}::TestPointsToBSplineInterpolation::test_closed_curve_interpolation', "-v"])
-    pytest.main([f'{__file__}', "-v"])
+    pytest.main([f"{__file__}", "-v"])


### PR DESCRIPTION
Changes:

- This PR updates the import statements across the test suite to use the proper `ocp_gordon` namespace, removing the `src_py`. prefix and the associated `sys.path` modifications.
- Removed now unneeded `sys` and `os` imports
- Removed now unneeded `sys.path.insert`
- Ran through black formatter which resulted in some unrelated formatting changes, these can be reverted if necessary

Motivation:

Currently, the tests rely on relative path hacks (sys.path.insert) to point directly at the local src_py directory. While this allows tests to run against the raw source code, it prevents the test suite from verifying the actual installed Python package.

When the package is built into a wheel or distributed via package managers (I am currently preparing the ocp-gordon feedstock for conda-forge), the src_py directory is stripped, and the code is correctly installed into the environment as simply ocp_gordon. Because the test files hardcoded the src_py prefix, pytest crashes with ModuleNotFoundError: No module named 'src_py' during the package verification stage.